### PR TITLE
fix: Disable prevent_destroy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.tfstate.backup
 *.zip
 *.hcl
+*.info
 !lambda_payload.zip

--- a/s3_bucket.tf
+++ b/s3_bucket.tf
@@ -19,7 +19,7 @@ resource "aws_s3_bucket" "munki-bucket" {
   lifecycle {
     # This can't be interpolationed as a variable. https://github.com/hashicorp/terraform/issues/3116
     # This bucket must be manually destroyed in the AWS console or via API for safety purposes.
-    prevent_destroy = true
+    prevent_destroy = false
   }
 
   tags = merge(
@@ -54,4 +54,3 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
     filter_prefix       = "pkgsinfo/"
   }
 }
-


### PR DESCRIPTION
Since we can’t easily provide this attribute to the module user this “safety net” needs to be removed.