### PR TITLE
fix: Explicitly denying http traffic

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -27,6 +27,21 @@ resource "aws_iam_policy" "munki-s3-rw" {
         "arn:aws:s3:::${var.s3_bucket_name}/*"
       ]
     }
+  ],
+  "Statement":[
+    {
+      "Effect": "Deny",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::${var.s3_bucket_name}",
+        "arn:aws:s3:::${var.s3_bucket_name}/*"
+      ],
+      "Condition": {
+          "Bool": {
+            "aws:SecureTransport": "false"
+          }
+      }
+    }
   ]
 }
 EOF

--- a/policy.tf
+++ b/policy.tf
@@ -27,21 +27,6 @@ resource "aws_iam_policy" "munki-s3-rw" {
         "arn:aws:s3:::${var.s3_bucket_name}/*"
       ]
     }
-  ],
-  "Statement":[
-    {
-      "Effect": "Deny",
-      "Action": "s3:*",
-      "Resource": [
-        "arn:aws:s3:::${var.s3_bucket_name}",
-        "arn:aws:s3:::${var.s3_bucket_name}/*"
-      ],
-      "Condition": {
-          "Bool": {
-            "aws:SecureTransport": "false"
-          }
-      }
-    }
   ]
 }
 EOF

--- a/s3_bucket.tf
+++ b/s3_bucket.tf
@@ -28,11 +28,6 @@ resource "aws_s3_bucket" "munki-bucket" {
   )
 }
 
-resource "aws_s3_bucket_acl" "munki-bucket" {
-  bucket = aws_s3_bucket.munki-bucket[0].bucket
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_policy" "munki-bucket" {
   bucket = aws_s3_bucket.munki-bucket[0].bucket
   policy = data.aws_iam_policy_document.munki_s3_policy.json

--- a/s3_bucket.tf
+++ b/s3_bucket.tf
@@ -8,6 +8,24 @@ data "aws_iam_policy_document" "munki_s3_policy" {
       identifiers = [aws_cloudfront_origin_access_identity.cf-identity.iam_arn]
     }
   }
+  statement {
+    effect = "Deny"
+    actions = [
+      "s3:*",
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = ["arn:aws:s3:::${var.s3_bucket_name}/*"]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+  }
 }
 
 resource "aws_s3_bucket" "munki-bucket" {


### PR DESCRIPTION
By default, Amazon S3 allows both HTTP and HTTPS requests. In order to allow access to Amazon S3 objects only through HTTPS you also have to explicitly deny access to HTTP requests. HTTPS uses TLS to encrypt all connections to the bucket. If a bucket's policy doesn't explicitly deny non-HTTPS connections, it puts the bucket in the risk of eavesdropping and man-in-the-middle attacks.